### PR TITLE
Fixed the logo in the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _Disclaimer: One, this documentation is out of date, two, I've made this for my own purposes so it's very suited to that, it likely won't work, out of the box, just like you want it to, or be very adaptable. But! Have a look if ya want, fork and change it all up!_
 
-![balrog](https://raw2.github.com/jlord/balrog/master/balrog.png)
+![balrog](https://raw.githubusercontent.com/jlord/balrog/master/balrog.png)
 ---
 
 A static site generator with these goals:


### PR DESCRIPTION
Fixed the broken image in README.md.

I guess `raw2` is deprecated, since it returns a 404. Maybe would it be nice to redirect automatically to `raw.githubusercontent.com`?

I tried to [hack the things](http://raw2.github.io/jlord/balrog/master/balrog.png), but `raw2.github.com` is not redirected to `raw2.github.io`, which is good. :smile: 